### PR TITLE
Proposal: Assign tile_format values for svg, avif, geojson, topojson, json and raw data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,13 @@ The file is composed of several parts:
 | `0`    | png             | `image/png`                |
 | `1`    | jpg             | `image/jpeg`               |
 | `2`    | webp            | `image/webp`               |
+| `3`    | svg             | `image/svg+xml`            |
+| `4`    | avif            | `image/avif`               |
 | `5-11` | *unassigned*    |                            |
+| `12`   | geojson         | `application/geo+json`     |
+| `13`   | topojson        | `application/topo+json`    |
+| `14`   | json            | `application/json`         |
+| `15`   | raw binary data | `application/octet-stream` |
 | `16`   | pbf             | `application/x-protobuf`   |
 
 ### `tile_precompression` values:

--- a/readme.md
+++ b/readme.md
@@ -30,15 +30,22 @@ The file is composed of several parts:
 | 54     | 8      | u64    | `length` of `block_index`        |
 
 ### `tile_format` values:
-  - `0`: png
-  - `1`: jpg
-  - `2`: webp
-  - `16`: pbf
+
+| value  | format          | mime-type                  |
+| ------ | --------------- | -------------------------- |
+| `0`    | png             | `image/png`                |
+| `1`    | jpg             | `image/jpeg`               |
+| `2`    | webp            | `image/webp`               |
+| `5-11` | *unassigned*    |                            |
+| `16`   | pbf             | `application/x-protobuf`   |
 
 ### `tile_precompression` values:
-  - `0`: uncompressed
-  - `1`: gzip compressed
-  - `2`: brotli compressed
+
+| value  | compression     | 
+| ------ | --------------- | 
+| `0`    | uncompressed    |
+| `1`    | gzip            |
+| `2`    | brotli          |
 
 ### `meta`
 


### PR DESCRIPTION
Since the opencloudtiles container can hold arbitrary data and more file formats than currently specified can be useful for and are in use by the broader mapping community i'm proposing the inclusion of these file formats in the specification.